### PR TITLE
Check nav list item has firstChild

### DIFF
--- a/navmore.js
+++ b/navmore.js
@@ -315,7 +315,7 @@
   function forEachFirstChildByTagName(startNode, tagNames, fn) {
     var children = startNode.children
     for (i = 0; i < children.length; i++) {
-      if(hasTagName(children[i].firstElementChild, tagNames)) {
+      if(children[i].firstElementChild && hasTagName(children[i].firstElementChild, tagNames)) {
         fn(children[i].firstElementChild);
       }
     }


### PR DESCRIPTION
This check is to fix a bug that occurs when the nav has a list-item with no child elements